### PR TITLE
CSS fix for long process names

### DIFF
--- a/sysmon/templates/sysmon/index.html
+++ b/sysmon/templates/sysmon/index.html
@@ -21,6 +21,7 @@
         line-height: 1em;
     }
     .graph .bar span { position: absolute; left: 1em; }
+    .module table td.proces { white-space: normal; }
 </style>
 
 {% if user.is_superuser %}
@@ -121,7 +122,7 @@
             </tr>
             {% for process in processes %}
             <tr>
-                <td>{{process.name}}</td>
+                <td class="process">{{process.name}}</td>
                 <td>{{process.pid}}</td>
                 <td>{{process.memory}}%</td>
                 <td>{{process.status}}</td>


### PR DESCRIPTION
This is a simple change to add wrapping to long process names. 

![screen shot 2013-05-28 at 1 32 35 pm](https://f.cloud.github.com/assets/659901/574347/b0366e9c-c7c6-11e2-9a23-f0cdc06a7a0a.png)
