### PR TITLE
CSS fix for long process names

### DIFF
--- a/sysmon/templates/sysmon/index.html
+++ b/sysmon/templates/sysmon/index.html
@@ -21,7 +21,7 @@
         line-height: 1em;
     }
     .graph .bar span { position: absolute; left: 1em; }
-    .module table td.proces { white-space: normal; }
+    .module table td.process { white-space: normal; }
 </style>
 
 {% if user.is_superuser %}

--- a/sysmon/templates/sysmon/index.html
+++ b/sysmon/templates/sysmon/index.html
@@ -21,6 +21,7 @@
         line-height: 1em;
     }
     .graph .bar span { position: absolute; left: 1em; }
+    .module table td.proces { white-space: normal; }
 </style>
 
 {% if user.is_superuser %}
@@ -121,7 +122,7 @@
             </tr>
             {% for process in processes %}
             <tr>
-                <td>{{process.name}}</td>
+                <td class="process">{{process.name}}</td>
                 <td>{{process.pid}}</td>
                 <td>{{process.memory}}%</td>
                 <td>{{process.status}}</td>


### PR DESCRIPTION
Fixes css for long process names by adding word wrapping.

_Before_
![screen shot 2013-05-28 at 1 32 35 pm](https://f.cloud.github.com/assets/659901/574358/1d1c9f18-c7c7-11e2-9ae5-afd31405949b.png)

_After_
![screen shot 2013-05-28 at 1 48 23 pm](https://f.cloud.github.com/assets/659901/574364/36435af4-c7c7-11e2-90e4-4cbc01d4d80d.png)
