### PR TITLE
Set percent to an integer in case of AccessDenied

### DIFF
--- a/sysmon/templatetags/sysmon_tags.py
+++ b/sysmon/templatetags/sysmon_tags.py
@@ -97,7 +97,7 @@ class SysMon(template.Node):
             try:
                 percent = process.get_memory_percent()
             except AccessDenied:
-                percent = "Access Denied"
+                percent = 0
             else:
                 percent = int(percent)
 


### PR DESCRIPTION
In order to sort on memory, percent needs to always be the same type
